### PR TITLE
Fix low-contrast text on featured work card and footer labels

### DIFF
--- a/personal.css
+++ b/personal.css
@@ -74,6 +74,8 @@ h3 { font-size: 1.24rem; }
 .work-grid, .insight-grid { gap: 1rem; }
 .work-card, .work-card.featured, .insight-card, .principle-card, .post-card { color: var(--ink); background: rgba(255, 255, 255, 0.72); border: 1px solid var(--line); border-radius: var(--radius); box-shadow: none; }
 .work-card.featured::after { display: none; }
+.work-card.featured p,
+.work-card.featured .work-meta { color: var(--muted); }
 .work-card:hover, .insight-card:hover, .post-card:hover { transform: translateY(-3px); box-shadow: var(--shadow); }
 .work-meta, .post-meta { color: var(--accent-dark); }
 .tag-list li { color: var(--ink-soft); background: var(--paper-deep); border-color: transparent; }
@@ -112,6 +114,7 @@ input:focus, select:focus, textarea:focus { border-color: var(--accent); box-sha
 .site-footer { margin-top: 4rem; padding: 4rem 0 1.5rem; color: var(--ink); background: #f2eee7; border-top: 1px solid var(--line); }
 .footer-brand p, .footer-links a, .footer-bottom { color: var(--muted); }
 .footer-links a:hover { color: var(--accent-dark); }
+.footer-links strong { color: var(--accent-dark); }
 .footer-bottom { border-color: var(--line); }
 
 @media (max-width: 820px) {


### PR DESCRIPTION
## Summary
The redesign's `personal.css` overrides `.work-card.featured` and `.site-footer` from styles.css's original dark-background treatment to a light one, but two child selectors kept their original light (dark-bg-appropriate) text color, making them barely readable:

- `.work-card.featured p` / `.work-meta` — description and meta text on the first "Selected work" card
- `.footer-links strong` — the "Explore"/"Connect" section labels in the footer

Fixed by giving both their own light-background-appropriate colors (`var(--muted)` and `var(--accent-dark)` respectively, matching the colors already used for equivalent text elsewhere on the site).

## Test plan
- [x] Verified via computed styles in-browser: featured card text now `rgb(105,119,121)` (readable dark gray) on its light card background
- [x] Verified footer labels now `rgb(50,105,100)` (solid teal) on the light cream footer background
- [x] No console errors